### PR TITLE
get rid of django deprecation fix caused by IPAddressField

### DIFF
--- a/admin_honeypot/migrations/0002_auto_20150527_1521.py
+++ b/admin_honeypot/migrations/0002_auto_20150527_1521.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('admin_honeypot', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='loginattempt',
+            name='ip_address',
+            field=models.GenericIPAddressField(null=True, verbose_name='ip address', blank=True),
+        ),
+    ]

--- a/admin_honeypot/models.py
+++ b/admin_honeypot/models.py
@@ -2,10 +2,16 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from admin_honeypot import listeners
 
+try:
+    from django.db.models import GenericIPAddressField
+except ImportError:
+    raise ImportError('Could not import GenericIPAddressField. admin_honeypot '
+                      'requires Django>=1.4 to be working.')
+
 
 class LoginAttempt(models.Model):
     username = models.CharField(_("username"), max_length=255, blank=True, null=True)
-    ip_address = models.IPAddressField(_("ip address"), blank=True, null=True)
+    ip_address = models.GenericIPAddressField(_("ip address"), blank=True, null=True)
     session_key = models.CharField(_("session key"), max_length=50, blank=True, null=True)
     user_agent = models.TextField(_("user-agent"), blank=True, null=True)
     timestamp = models.DateTimeField(_("timestamp"), auto_now_add=True)

--- a/admin_honeypot/south_migrations/0005_auto__chg_field_loginattempt_ip_address.py
+++ b/admin_honeypot/south_migrations/0005_auto__chg_field_loginattempt_ip_address.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'LoginAttempt.ip_address'
+        db.alter_column(u'admin_honeypot_loginattempt', 'ip_address', self.gf('django.db.models.fields.GenericIPAddressField')(max_length=39, null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'LoginAttempt.ip_address'
+        db.alter_column(u'admin_honeypot_loginattempt', 'ip_address', self.gf('django.db.models.fields.IPAddressField')(max_length=15, null=True))
+
+    models = {
+        u'admin_honeypot.loginattempt': {
+            'Meta': {'ordering': "('timestamp',)", 'object_name': 'LoginAttempt'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip_address': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'path': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'session_key': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user_agent': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['admin_honeypot']


### PR DESCRIPTION
This fixes #24 and improves pull request #26 with a human readable error message and south/django migrations.

I didn't find any documentation where I could increase the minimum django version