### PR TITLE
get ip from settings ip header

### DIFF
--- a/admin_honeypot/views.py
+++ b/admin_honeypot/views.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views import generic
+from django.conf import settings
 
 
 class AdminHoneypot(generic.FormView):
@@ -45,7 +46,8 @@ class AdminHoneypot(generic.FormView):
         instance = LoginAttempt.objects.create(
             username=self.request.POST.get('username'),
             session_key=self.request.session.session_key,
-            ip_address=self.request.META.get('REMOTE_ADDR'),
+            ip_address=self.request.META.get(
+                getattr(settings, 'ADMIN_HONEYPOT_IP_HEADER', 'REMOTE_ADDR')),
             user_agent=self.request.META.get('HTTP_USER_AGENT'),
             path=self.request.get_full_path(),
         )


### PR DESCRIPTION
Hello, I'm using nginx and remote ip is stored in the header `HTTP_X_REAL_IP`. Not to create middleware to override the header. In settings easier to use a name with IP address header.
```python
ADMIN_HONEYPOT_IP_HEADER = 'HTTP_X_REAL_IP'
```

sorry for bad English