### PR TITLE
Fix missing django settings configuration for py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
                        django17_py27, django17_py33, django17_py34
 
 [testenv]
-commands = py.test tests/
+commands = py.test tests/ --ds=tests.settings
 deps =
     pytest
     pytest-django
@@ -20,7 +20,7 @@ deps =
 [testenv:coverage]
 basepython = python2.7
 commands =
-    py.test tests/ --cov admin_honeypot --cov-config .coveragerc --cov-report term-missing --pep8 admin_honeypot
+    py.test tests/ --ds=tests.settings --cov admin_honeypot --cov-config .coveragerc --cov-report term-missing --pep8 admin_honeypot
     coveralls
 deps =
     Django==1.7


### PR DESCRIPTION
This should fix the tox tests.