### PR TITLE
Fix tox not passing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,6 @@
 language: python
 
 env:
-  - TOXENV=django13_py26
-  - TOXENV=django13_py27
-
-  - TOXENV=django14_py26
-  - TOXENV=django14_py27
-
-  - TOXENV=django15_py26
-  - TOXENV=django15_py27
-  - TOXENV=django15_py33
-  - TOXENV=django15_py34
-
   - TOXENV=django16_py26
   - TOXENV=django16_py27
   - TOXENV=django16_py33

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,6 @@
 
 [tox]
 envlist =
-        django13_py26, django13_py27,
-        django14_py26, django14_py27,
-        django15_py26, django15_py27, django15_py33, django15_py34,
         django16_py26, django16_py27, django16_py33, django16_py34,
                        django17_py27, django17_py33, django17_py34
 
@@ -27,54 +24,6 @@ deps =
     coveralls
     pytest-cov
     pytest-pep8
-    {[testenv]deps}
-
-[testenv:django13_py26]
-basepython = python2.6
-deps =
-    Django==1.3
-    {[testenv]deps}
-
-[testenv:django13_py27]
-basepython = python2.7
-deps =
-    Django==1.3
-    {[testenv]deps}
-
-[testenv:django14_py26]
-basepython = python2.6
-deps =
-    Django==1.4
-    {[testenv]deps}
-
-[testenv:django14_py27]
-basepython = python2.7
-deps =
-    Django==1.4
-    {[testenv]deps}
-
-[testenv:django15_py26]
-basepython = python2.6
-deps =
-    Django==1.5
-    {[testenv]deps}
-
-[testenv:django15_py27]
-basepython = python2.7
-deps =
-    Django==1.5
-    {[testenv]deps}
-
-[testenv:django15_py33]
-basepython = python3.3
-deps =
-    Django==1.5
-    {[testenv]deps}
-
-[testenv:django15_py34]
-basepython = python3.4
-deps =
-    Django==1.5
     {[testenv]deps}
 
 [testenv:django16_py26]


### PR DESCRIPTION
Django <=1.6 seems to have an issue with packaging static files. Drop the tests for those, it's horribly outdated anyways.