### PR TITLE
Fixed form_class warning that will become deprecated in Django1.10

### DIFF
--- a/admin_honeypot/views.py
+++ b/admin_honeypot/views.py
@@ -26,7 +26,7 @@ class AdminHoneypot(generic.FormView):
 
         return super(AdminHoneypot, self).dispatch(request, *args, **kwargs)
 
-    def get_form(self, form_class):
+    def get_form(self, form_class=form_class):
         return form_class(self.request, **self.get_form_kwargs())
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Added a default value for the form_class variable in the function get_form. This will be deprecated in Django1.10:

~/admin_honeypot/views.py:13: RemovedInDjango110Warning: `admin_honeypot.views.AdminHoneypot.get_form` method must define a default value for its `form_class` argument.
