### PR TITLE
Added compatibility with Django 2.0 and Python 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,16 @@ language: python
 
 env:
   - TOXENV=django18_py27
-  - TOXENV=django18_py33
   - TOXENV=django18_py34
   - TOXENV=django18_py35
 
   - TOXENV=django19_py27
   - TOXENV=django19_py34
   - TOXENV=django19_py35
+
+  - TOXENV=django20_py34
+  - TOXENV=django20_py35
+  - TOXENV=django20_py36
 
   - TOXENV=coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
       python: '3.4'
     - env: TOXENV=django111-py35
       python: '3.5'
-    - env: TOXENV=django111-py35
+    - env: TOXENV=django111-py36
       python: '3.6'
 
     - env: TOXENV=django20-py34

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,12 @@ matrix:
     - env: TOXENV=django111-py35
       python: '3.6'
 
-    - env: TOXENV=django20-py27
-      python: '3.4'
     - env: TOXENV=django20-py34
-      python: '3.5'
+      python: '3.4'
     - env: TOXENV=django20-py35
+      python: '3.5'
+    - env: TOXENV=django20-py36
       python: '3.6'
-
     - env: TOXENV=coverage
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,47 @@
 language: python
 
-env:
-  - TOXENV=django18_py27
-  - TOXENV=django18_py34
-  - TOXENV=django18_py35
+matrix:
+  include:
+    - env: TOXENV=django18_py27
+      python: '2.7'
+    - env: TOXENV=django18_py34
+      python: '3.3'
+    - env: TOXENV=django18_py34
+      python: '3.4'
+    - env: TOXENV=django18_py35
+      python: '3.5'
 
-  - TOXENV=django19_py27
-  - TOXENV=django19_py34
-  - TOXENV=django19_py35
+    - env: TOXENV=django19_py27
+      python: '2.7'
+    - env: TOXENV=django19_py34
+      python: '3.4'
+    - env: TOXENV=django19_py35
+      python: '3.5'
 
-  - TOXENV=django20_py34
-  - TOXENV=django20_py35
-  - TOXENV=django20_py36
+    - env: TOXENV=django110_py27
+      python: '2.7'
+    - env: TOXENV=django110_py34
+      python: '3.4'
+    - env: TOXENV=django110_py35
+      python: '3.5'
 
-  - TOXENV=coverage
+    - env: TOXENV=django111_py27
+      python: '2.7'
+    - env: TOXENV=django111_py34
+      python: '3.4'
+    - env: TOXENV=django111_py35
+      python: '3.5'
+    - env: TOXENV=django111_py35
+      python: '3.6'
+
+    - env: TOXENV=django20_py27
+      python: '3.4'
+    - env: TOXENV=django20_py34
+      python: '3.5'
+    - env: TOXENV=django20_py35
+      python: '3.6'
+
+    - env: TOXENV=coverage
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,43 +2,43 @@ language: python
 
 matrix:
   include:
-    - env: TOXENV=django18_py27
+    - env: TOXENV=django18-py27
       python: '2.7'
-    - env: TOXENV=django18_py34
+    - env: TOXENV=django18-py34
       python: '3.3'
-    - env: TOXENV=django18_py34
+    - env: TOXENV=django18-py34
       python: '3.4'
-    - env: TOXENV=django18_py35
+    - env: TOXENV=django18-py35
       python: '3.5'
 
-    - env: TOXENV=django19_py27
+    - env: TOXENV=django19-py27
       python: '2.7'
-    - env: TOXENV=django19_py34
+    - env: TOXENV=django19-py34
       python: '3.4'
-    - env: TOXENV=django19_py35
+    - env: TOXENV=django19-py35
       python: '3.5'
 
-    - env: TOXENV=django110_py27
+    - env: TOXENV=django110-py27
       python: '2.7'
-    - env: TOXENV=django110_py34
+    - env: TOXENV=django110-py34
       python: '3.4'
-    - env: TOXENV=django110_py35
+    - env: TOXENV=django110-py35
       python: '3.5'
 
-    - env: TOXENV=django111_py27
+    - env: TOXENV=django111-py27
       python: '2.7'
-    - env: TOXENV=django111_py34
+    - env: TOXENV=django111-py34
       python: '3.4'
-    - env: TOXENV=django111_py35
+    - env: TOXENV=django111-py35
       python: '3.5'
-    - env: TOXENV=django111_py35
+    - env: TOXENV=django111-py35
       python: '3.6'
 
-    - env: TOXENV=django20_py27
+    - env: TOXENV=django20-py27
       python: '3.4'
-    - env: TOXENV=django20_py34
+    - env: TOXENV=django20-py34
       python: '3.5'
-    - env: TOXENV=django20_py35
+    - env: TOXENV=django20-py35
       python: '3.6'
 
     - env: TOXENV=coverage

--- a/README.rst
+++ b/README.rst
@@ -39,11 +39,18 @@ tl;dr
 * Update your urls.py:
 
     ::
-
+        # If django version is lower than 2.0
         urlpatterns = patterns(''
             ...
             url(r'^admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
             url(r'^secret/', include(admin.site.urls)),
         )
+
+        # Otherwise
+        from django.urls import path
+        urlpatterns = [
+            path('admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
+            path('secret/', admin.site.urls),
+        ]
 
 * Run ``python manage.py migrate``

--- a/admin_honeypot/compat.py
+++ b/admin_honeypot/compat.py
@@ -1,0 +1,15 @@
+"""
+Compatibility layer for various django and python versions imports
+"""
+
+try:
+    from django.urls import reverse
+except ImportError:  # For Django version less than 2.0
+    from django.core.urlresolvers import reverse  # noqa
+
+try:
+    # Python 2.7
+    from urllib import quote_plus
+except ImportError:
+    # Python 3+
+    from urllib.parse import quote_plus  # noqa

--- a/admin_honeypot/listeners.py
+++ b/admin_honeypot/listeners.py
@@ -1,7 +1,8 @@
+from admin_honeypot.compat import reverse
 from admin_honeypot.signals import honeypot
+
 from django.conf import settings
 from django.core.mail import mail_admins
-from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 
 
@@ -16,6 +17,7 @@ def notify_admins(instance, request, **kwargs):
     subject = render_to_string('admin_honeypot/email_subject.txt', context).strip()
     message = render_to_string('admin_honeypot/email_message.txt', context).strip()
     mail_admins(subject=subject, message=message)
+
 
 if getattr(settings, 'ADMIN_HONEYPOT_EMAIL_ADMINS', True):
     honeypot.connect(notify_admins)

--- a/admin_honeypot/models.py
+++ b/admin_honeypot/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from admin_honeypot import listeners
+from admin_honeypot import listeners  # noqa
 
 
 class LoginAttempt(models.Model):

--- a/admin_honeypot/urls.py
+++ b/admin_honeypot/urls.py
@@ -1,6 +1,8 @@
 from admin_honeypot import views
 from django.conf.urls import url
 
+app_name = 'admin_honeypot'
+
 urlpatterns = [
     url(r'^login/$', views.AdminHoneypot.as_view(), name='login'),
     url(r'^.*$', views.AdminHoneypot.as_view(), name='index'),

--- a/admin_honeypot/views.py
+++ b/admin_honeypot/views.py
@@ -1,10 +1,10 @@
 import django
+from admin_honeypot.compat import reverse
 from admin_honeypot.forms import HoneypotLoginForm
 from admin_honeypot.models import LoginAttempt
 from admin_honeypot.signals import honeypot
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
-from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views import generic

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,10 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
@@ -26,8 +30,9 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-        ],
+    ],
     keywords='django admin honeypot trap',
     maintainer='Derek Payton',
     maintainer_email='derek.payton@gmail.com',
@@ -37,4 +42,4 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     zip_safe=False,
-    )
+)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -38,12 +38,18 @@ INSTALLED_APPS = (
     'admin_honeypot',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 )
 
+TEMPLATES = [
+    {
+        'APP_DIRS': True,
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    },
+]
 
 ADMIN_HONEYPOT_EMAIL_ADMINS = True

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,13 +1,18 @@
-try:
-    from django.conf.urls import patterns, include, url
-except ImportError:  # django < 1.4
-    from django.conf.urls.defaults import patterns, include, url
+import django
+from django.conf.urls import include, url
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    url(r'^admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
-    url(r'^secret/', include(admin.site.urls)),
-)
+if django.VERSION < (2, 0):
+    urlpatterns = [
+        url(r'^admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
+        url(r'^secret/', include(admin.site.urls)),
+    ]
+else:
+    from django.urls import path
+    urlpatterns = [
+        path('admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
+        path('secret/', admin.site.urls),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@
 [tox]
 envlist =
         django18_py27, django18_py33, django18_py34, django18_py35
-        django19_py27,                django19_py34, django19_py35
+        django19_py27,                django19_py34, django19_py35,
+                                      django20_py34, django20_py35, django20_py36,
 
 [testenv]
 commands = py.test tests/
@@ -22,7 +23,7 @@ commands =
     py.test tests/ --cov admin_honeypot --cov-config .coveragerc --cov-report term-missing --pep8 admin_honeypot
     coveralls
 deps =
-    Django>=1.9,<1.10
+    Django>=1.9,<=2.0
     coveralls
     pytest-cov
     pytest-pep8
@@ -74,4 +75,22 @@ deps =
 basepython = python3.5
 deps =
     Django>=1.9,<1.10
+    {[testenv]deps}
+
+[testenv:django20_py34]
+basepython = python3.4
+deps =
+    Django==2.0.2
+    {[testenv]deps}
+
+[testenv:django20_py35]
+basepython = python3.5
+deps =
+    Django==2.0.2
+    {[testenv]deps}
+
+[testenv:django20_py36]
+basepython = python3.6
+deps =
+    Django==2.0.2
     {[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 
 [tox]
 envlist =
-        django18_py27, django18_py33, django18_py34, django18_py35
-        django19_py27,                django19_py34, django19_py35,
-                                      django20_py34, django20_py35, django20_py36,
+        django18_py27, django18_py34, django18_py35
+        django19_py27, django19_py34, django19_py35,
+                       django20_py34, django20_py35, django20_py36,
 
 [testenv]
 commands = py.test tests/

--- a/tox.ini
+++ b/tox.ini
@@ -5,16 +5,27 @@
 
 [tox]
 envlist =
-        django18_py27, django18_py34, django18_py35
-        django19_py27, django19_py34, django19_py35,
-                       django20_py34, django20_py35, django20_py36,
+        django18-py{27,33,34,35}
+        django19-py{27,34,35}
+        django110-py{27,34,35}
+        django111-py{27,34,35,36}
+        django20-py{34,35,36}
 
-[testenv]
-commands = py.test tests/
+[testenvbase]
 deps =
     pytest
     pytest-django
     pytest-pythonpath
+
+[testenv]
+commands = py.test tests/
+deps =
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2
+    django20: Django==2.0.2
+    {[testenvbase]deps}
 
 [testenv:coverage]
 basepython = python2.7
@@ -27,70 +38,4 @@ deps =
     coveralls
     pytest-cov
     pytest-pep8
-    {[testenv]deps}
-
-[testenv:django18_py27]
-basepython = python2.7
-deps =
-    Django>=1.8,<1.9
-    {[testenv]deps}
-
-[testenv:django18_py33]
-basepython = python3.3
-deps =
-    Django>=1.8,<1.9
-    {[testenv]deps}
-
-[testenv:django18_py34]
-basepython = python3.4
-deps =
-    Django>=1.8,<1.9
-    {[testenv]deps}
-
-[testenv:django18_py35]
-basepython = python3.5
-deps =
-    Django>=1.8,<1.9
-    {[testenv]deps}
-
-[testenv:django19_py27]
-basepython = python2.7
-deps =
-    Django>=1.9,<1.10
-    {[testenv]deps}
-
-[testenv:django19_py33]
-basepython = python3.3
-deps =
-    Django>=1.9,<1.10
-    {[testenv]deps}
-
-[testenv:django19_py34]
-basepython = python3.4
-deps =
-    Django>=1.9,<1.10
-    {[testenv]deps}
-
-[testenv:django19_py35]
-basepython = python3.5
-deps =
-    Django>=1.9,<1.10
-    {[testenv]deps}
-
-[testenv:django20_py34]
-basepython = python3.4
-deps =
-    Django==2.0.2
-    {[testenv]deps}
-
-[testenv:django20_py35]
-basepython = python3.5
-deps =
-    Django==2.0.2
-    {[testenv]deps}
-
-[testenv:django20_py36]
-basepython = python3.6
-deps =
-    Django==2.0.2
-    {[testenv]deps}
+    {[testenvbase]deps}


### PR DESCRIPTION
This PR has a part of https://github.com/dmpayton/django-admin-honeypot/pull/47 PR (travis env list)
- URL resolving is now compatible with both 2.0 and older versions
- CSRF token is now correctly handled in tests for versions 1.11+
- Tox environments updated
- Minor documentation fixes.