### PR TITLE
Update missing db migration step in documentation

### DIFF
--- a/docs/manual/usage.rst
+++ b/docs/manual/usage.rst
@@ -22,6 +22,10 @@ Basic setup
         ...
     )
 
+3. Run migration::
+
+   $ python manage.py migrate
+
 The ``honeypot`` signal
 =======================
 


### PR DESCRIPTION
I got an error table does not exist when following the tutorial in readthedocs.io