### PR TITLE
Modify code snippet for "real" Admin page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ tl;dr
         urlpatterns = patterns(''
             ...
             url(r'^admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
-            url(r'^secret/', include(admin.site.urls)),
+            url(r'^secret/', admin.site.urls),
         )
 
 * Run ``python manage.py migrate``


### PR DESCRIPTION
Hello! Thanks for such a useful Django package!

I encountered this error after using the code snippet provided in the README:

```
url(r'^secret-admin/', include(admin.site.urls)),
  File "/Users/erin/my-site/my-env/lib/python3.7/site-packages/django/urls/conf.py", line 27, in include
'provide the namespace argument to include() instead.' % len(arg)
django.core.exceptions.ImproperlyConfigured: Passing a 3-tuple to include() is not supported. Pass a 2-tuple containing the list of patterns and app_name, and provide the namespace argument to include() instead.
```

I copied the error message into a Google search and found [this blog post](https://timonweb.com/tutorials/solving-djangocoreexceptionsimproperlyconfigured-passing-a-3-tuple-to-include-error-after-djangowagtail-20-upgrade/). Making the code change suggestion therein resolved the issue.

Submitting this PR in case you would like to incorporate this change into your README.