### PR TITLE
Functional links in admin and applicacion configuration

### DIFF
--- a/admin_honeypot/__init__.py
+++ b/admin_honeypot/__init__.py
@@ -3,3 +3,5 @@ __copyright__ = 'Copyright (c) Derek Payton'
 __description__ = 'A fake Django admin login screen to notify admins of attempted unauthorized access.'
 __version__ = '1.1.0'
 __license__ = 'MIT License'
+
+default_app_config = 'admin_honeypot.apps.AuthConfig'

--- a/admin_honeypot/admin.py
+++ b/admin_honeypot/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from admin_honeypot.models import LoginAttempt
@@ -17,19 +18,16 @@ class LoginAttemptAdmin(admin.ModelAdmin):
         return actions
 
     def get_session_key(self, instance):
-        return '<a href="?session_key=%(key)s">%(key)s</a>' % {'key': instance.session_key}
+        return mark_safe('<a href="?session_key=%(key)s">%(key)s</a>' % {'key': instance.session_key})
     get_session_key.short_description = _('Session')
-    get_session_key.allow_tags = True
 
     def get_ip_address(self, instance):
-        return '<a href="?ip_address=%(ip)s">%(ip)s</a>' % {'ip': instance.ip_address}
+        return mark_safe('<a href="?ip_address=%(ip)s">%(ip)s</a>' % {'ip': instance.ip_address})
     get_ip_address.short_description = _('IP Address')
-    get_ip_address.allow_tags = True
 
     def get_path(self, instance):
-        return '<a href="?path=%(path)s">%(path)s</a>' % {'path': instance.path}
+        return mark_safe('<a href="?path=%(path)s">%(path)s</a>' % {'path': instance.path})
     get_path.short_description = _('URL')
-    get_path.allow_tags = True
 
     def has_add_permission(self, request, obj=None):
         return False

--- a/admin_honeypot/apps.py
+++ b/admin_honeypot/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class AuthConfig(AppConfig):
+    name = 'admin_honeypot'
+    verbose_name = _("Admin Honeypot")


### PR DESCRIPTION
I've replaced allow_tags for mark_safe in admin list view to recover the links in it as it was deprecated in Django 1.9 https://code.djangoproject.com/ticket/25135 and removed in Django 2.0 https://docs.djangoproject.com/en/3.0/releases/2.0/#features-removed-in-2-0

Also, I added an application configuration file as recommended in https://docs.djangoproject.com/en/1.7/ref/applications/#for-application-authors