### PR TITLE
Integrate Ipware to avoid all the cornercases where the real ip is no…

### DIFF
--- a/admin_honeypot/views.py
+++ b/admin_honeypot/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.views import generic
+from ipware import get_client_ip
 
 
 class AdminHoneypot(generic.FormView):
@@ -43,10 +44,11 @@ class AdminHoneypot(generic.FormView):
         return self.form_invalid(form)
 
     def form_invalid(self, form):
+        ip, is_routable = get_client_ip(self.request)
         instance = LoginAttempt.objects.create(
             username=self.request.POST.get('username'),
             session_key=self.request.session.session_key,
-            ip_address=self.request.META.get('REMOTE_ADDR'),
+            ip_address=ip,
             user_agent=self.request.META.get('HTTP_USER_AGENT'),
             path=self.request.get_full_path(),
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-django
 pytest-pep8
 pytest-pythonpath
+django-ipware==2.1.0


### PR DESCRIPTION
Integrate Ipware to avoid all the corner cases where the real ip is not in REMOTE ADDR header -like when Django is running behind a proxy or in docker-
