### PR TITLE
Fix IP identification when behind load balancer or proxy

### DIFF
--- a/admin_honeypot/views.py
+++ b/admin_honeypot/views.py
@@ -43,10 +43,18 @@ class AdminHoneypot(generic.FormView):
         return self.form_invalid(form)
 
     def form_invalid(self, form):
+    
+        #Get IP if behind load balancer / proxy
+        x_forwarded_for = self.request.META.get('HTTP_X_FORWARDED_FOR')
+        if x_forwarded_for:
+            ip = self.x_forwarded_for.split(',')[0]
+        else:
+            ip = self.request.META.get('REMOTE_ADDR')
+     
         instance = LoginAttempt.objects.create(
             username=self.request.POST.get('username'),
             session_key=self.request.session.session_key,
-            ip_address=self.request.META.get('REMOTE_ADDR'),
+            ip_address=ip,
             user_agent=self.request.META.get('HTTP_USER_AGENT'),
             path=self.request.get_full_path(),
         )


### PR DESCRIPTION
Currently the user IP address cannot be collected properly if the site is behind a load balancer or proxy. This code adds a fallback in those situations so that the user IP can be collected properly.

Without this, it is impossible to correctly identify a user IP and so there is no way to ban any malicious users. 